### PR TITLE
Fixed issue #389 - by managing quiz/question state differently.

### DIFF
--- a/client/src/actions/auth.ts
+++ b/client/src/actions/auth.ts
@@ -68,7 +68,7 @@ export const getProfile = (semesterId = null) => async (dispatch, getState) => {
   try {
     [res] = await Promise.all([
       axios.get(`/api/users/${userId}/profile?semesterId=${semesterId}`),
-      dispatch(getQuestions({ profile: true }))
+      dispatch(getQuestions({ quiz: false }))
     ]);
   } catch ({ response }) {
     dispatch(makeToast('toast.auth.fetchProfileError', 'error'));

--- a/client/src/actions/question.ts
+++ b/client/src/actions/question.ts
@@ -5,10 +5,12 @@ import { Dispatch } from 'redux';
 
 const questionApi = '/api/questions';
 
-export const getQuestions = ({ ids = null, quiz = true, profile = !quiz }) => async (
-  dispatch,
-  getState
-) => {
+export const getQuestions = ({
+  ids = null,
+  quiz = true,
+  profile = !quiz,
+  refetch = false
+}) => async (dispatch, getState) => {
   dispatch({ type: types.FETCH_QUESTIONS_REQUEST });
   let state = getState();
   let {
@@ -73,7 +75,8 @@ export const getQuestions = ({ ids = null, quiz = true, profile = !quiz }) => as
     dispatch({
       type: types.FETCH_QUESTIONS_SUCCESS,
       payload: res.data,
-      quiz
+      quiz,
+      refetch
     });
   } else {
     dispatch({

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -35,14 +35,20 @@ const migrations: any = {
       questions: state.questions
     };
   },
-  7: () => ({})
+  7: () => ({}),
+  8: (state: IReduxState) => ({
+    auth: state.auth,
+    settings: state.settings,
+    ui: state.ui,
+    shareBuilder: state.shareBuilder
+  })
 };
 
 const persistConfig = {
   key: 'medMCQ',
   storage: storage,
   stateReconciler: autoMergeLevel2, // see "Merge Process" section for details.
-  version: 7,
+  version: 8,
   migrate: createMigrate(migrations),
   whitelist: ['quiz', 'questions', 'metadata', 'ui', 'settings', 'shareBuilder'] // to disable persists
 };

--- a/client/src/pages/Quiz.jsx
+++ b/client/src/pages/Quiz.jsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
-import _ from 'lodash';
 import { withLocalize, Translate } from 'react-localize-redux';
 import quizTranslations from '../Translations/quizTranslations.json';
 
@@ -52,7 +51,11 @@ class QuizMain extends Component {
 
     let { quiz, questions } = this.props;
 
-    if (!_.isEqual(quiz.questions, questions.result) && !questions.isFetching) {
+    /*
+    Hvis quizzen er invalid (dvs. vi har hentet spørgsmål via fx profilsiden)
+    og vi ikke er ved at hente nye spørgsmål, henter vi spørgsmål igen:
+    */
+    if (quiz.didInvalidate && !questions.isFetching) {
       this.props.getQuestions({ ids: quiz.questions });
     }
   }
@@ -139,8 +142,12 @@ class QuizMain extends Component {
 
   render() {
     let { questions, user, quiz } = this.props;
-    let { answers } = quiz;
-    if (questions.isFetching) {
+    let { answers, didInvalidate } = quiz;
+    /* 
+    Hvis vi er ved at hente spørgsmål eller quizzen er invalid (-- i så fald henter vi nye spørgsmål
+    i componentDidMount) 
+    */
+    if (questions.isFetching || didInvalidate) {
       return (
         <Translate>
           {({ translate }) => (

--- a/client/src/pages/Quiz.jsx
+++ b/client/src/pages/Quiz.jsx
@@ -56,7 +56,7 @@ class QuizMain extends Component {
     og vi ikke er ved at hente nye spørgsmål, henter vi spørgsmål igen:
     */
     if (quiz.didInvalidate && !questions.isFetching) {
-      this.props.getQuestions({ ids: quiz.questions });
+      this.props.getQuestions({ ids: quiz.questions, refetch: true });
     }
   }
   componentWillUnmount() {

--- a/client/src/reducers/quizReducer.js
+++ b/client/src/reducers/quizReducer.js
@@ -11,7 +11,8 @@ const initialState = {
   questions: [],
   answers: {},
   quizId: null,
-  currentQuestion: 0
+  currentQuestion: 0,
+  didInvalidate: false
 };
 
 /**
@@ -24,6 +25,12 @@ export default createReducer(initialState, {
       state.questions = action.payload.map((q) => q.id);
       state.currentQuestion = 0;
       state.answers = {};
+      state.didInvalidate = false;
+    } else {
+      // Hvis vi henter nogle spørgsmål, der ikke hører til quizzen, gør
+      // vi quizzen invalid, så Quiz.tsx ved, at den skal bede om at genhente
+      // spørgsmålene.
+      state.didInvalidate = true;
     }
   },
 

--- a/client/src/reducers/quizReducer.js
+++ b/client/src/reducers/quizReducer.js
@@ -23,8 +23,11 @@ export default createReducer(initialState, {
   [types.FETCH_QUESTIONS_SUCCESS]: (state, action) => {
     if (action.quiz) {
       state.questions = action.payload.map((q) => q.id);
-      state.currentQuestion = 0;
-      state.answers = {};
+      console.log(action);
+      if (!action.refetch) {
+        state.currentQuestion = 0;
+        state.answers = {};
+      }
       state.didInvalidate = false;
     } else {
       // Hvis vi henter nogle spørgsmål, der ikke hører til quizzen, gør

--- a/client/src/reducers/quizReducer.js
+++ b/client/src/reducers/quizReducer.js
@@ -23,12 +23,12 @@ export default createReducer(initialState, {
   [types.FETCH_QUESTIONS_SUCCESS]: (state, action) => {
     if (action.quiz) {
       state.questions = action.payload.map((q) => q.id);
-      console.log(action);
+      state.didInvalidate = false;
+
       if (!action.refetch) {
         state.currentQuestion = 0;
         state.answers = {};
       }
-      state.didInvalidate = false;
     } else {
       // Hvis vi henter nogle spørgsmål, der ikke hører til quizzen, gør
       // vi quizzen invalid, så Quiz.tsx ved, at den skal bede om at genhente


### PR DESCRIPTION
Når man henter spørgsmål via profilsiden, gør man nu quizzen "invalid". Når Quiz.tsx component loades, beder den derfor om at genhente de spørgsmål, der var i den seneste quiz.